### PR TITLE
feat(chat): support local, worktree, and remote branches

### DIFF
--- a/apps/desktop/src/main/agent/agent-store.ts
+++ b/apps/desktop/src/main/agent/agent-store.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type { AgentSessionInfo, SubagentWorktreeInfo } from "../../shared/contracts";
+import type {
+  AgentSessionInfo,
+  SessionWorktreeInfo,
+  SubagentWorktreeInfo,
+} from "../../shared/contracts";
 import { getDatabase } from "../db/database";
 
 type AgentSessionRow = {
@@ -7,6 +11,7 @@ type AgentSessionRow = {
   workspace_id: string;
   title: string;
   cwd: string;
+  branch: string | null;
   status: AgentSessionInfo["status"];
   runtime: "pi-sdk" | "pi-rpc";
   model: string | null;
@@ -16,6 +21,11 @@ type AgentSessionRow = {
   subagent_task: string | null;
   subagent_type: string | null;
   subagent_readonly: number;
+  worktree_path: string | null;
+  worktree_branch: string | null;
+  worktree_base_branch: string | null;
+  worktree_base_sha: string | null;
+  worktree_status: string | null;
   subagent_worktree_path: string | null;
   subagent_worktree_branch: string | null;
   subagent_worktree_base_sha: string | null;
@@ -28,8 +38,9 @@ type AgentSessionRow = {
   updated_at: string;
 };
 
-const SESSION_COLUMNS = `id, workspace_id, title, cwd, status, runtime, model, pi_session_id,
+const SESSION_COLUMNS = `id, workspace_id, title, cwd, branch, status, runtime, model, pi_session_id,
   pi_session_file, parent_session_id, subagent_task, subagent_type, subagent_readonly,
+  worktree_path, worktree_branch, worktree_base_branch, worktree_base_sha, worktree_status,
   subagent_worktree_path, subagent_worktree_branch, subagent_worktree_base_sha,
   subagent_integration_status, subagent_changed_files_json, subagent_conflict_files_json,
   pinned_at, archived_at, created_at, updated_at`;
@@ -58,6 +69,9 @@ function toSession(row: AgentSessionRow): AgentSessionInfo {
     updatedAt: row.updated_at,
   };
 
+  if (row.branch !== null) {
+    session.branch = row.branch;
+  }
   if (row.model !== null) {
     session.model = row.model;
   }
@@ -86,6 +100,21 @@ function toSession(row: AgentSessionRow): AgentSessionInfo {
     session.subagentReadOnly = true;
   }
   if (
+    row.worktree_path !== null &&
+    row.worktree_branch !== null &&
+    row.worktree_base_branch !== null &&
+    row.worktree_base_sha !== null
+  ) {
+    const status = row.worktree_status as SessionWorktreeInfo["status"] | null;
+    session.worktree = {
+      path: row.worktree_path,
+      branch: row.worktree_branch,
+      baseBranch: row.worktree_base_branch,
+      baseSha: row.worktree_base_sha,
+      status: status ?? "active",
+    };
+  }
+  if (
     row.subagent_worktree_path !== null &&
     row.subagent_worktree_branch !== null &&
     row.subagent_worktree_base_sha !== null
@@ -112,6 +141,7 @@ export function createAgentSessionRecord(input: {
   workspaceId: string;
   title: string;
   cwd: string;
+  branch?: string;
   runtime?: "pi-sdk" | "pi-rpc";
   model?: string;
   piSessionId?: string;
@@ -120,6 +150,7 @@ export function createAgentSessionRecord(input: {
   subagentTask?: string;
   subagentType?: string;
   subagentReadOnly?: boolean;
+  worktree?: SessionWorktreeInfo;
   subagentWorktree?: SubagentWorktreeInfo;
 }): AgentSessionInfo {
   const now = new Date().toISOString();
@@ -135,6 +166,9 @@ export function createAgentSessionRecord(input: {
     updatedAt: now,
   };
 
+  if (input.branch !== undefined) {
+    session.branch = input.branch;
+  }
   if (input.model !== undefined) {
     session.model = input.model;
   }
@@ -156,25 +190,30 @@ export function createAgentSessionRecord(input: {
   if (input.subagentReadOnly !== undefined) {
     session.subagentReadOnly = input.subagentReadOnly;
   }
+  if (input.worktree !== undefined) {
+    session.worktree = input.worktree;
+  }
   if (input.subagentWorktree !== undefined) {
     session.subagentWorktree = input.subagentWorktree;
   }
   getDatabase()
     .prepare(
       `insert into agent_sessions (
-        id, workspace_id, title, cwd, status, runtime, model, pi_session_id, pi_session_file,
+        id, workspace_id, title, cwd, branch, status, runtime, model, pi_session_id, pi_session_file,
         parent_session_id, subagent_task, subagent_type, subagent_readonly,
+        worktree_path, worktree_branch, worktree_base_branch, worktree_base_sha, worktree_status,
         subagent_worktree_path, subagent_worktree_branch, subagent_worktree_base_sha,
         subagent_integration_status, subagent_changed_files_json, subagent_conflict_files_json,
         created_at, updated_at
        )
-       values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       session.id,
       session.workspaceId,
       session.title,
       session.cwd,
+      session.branch ?? null,
       session.status,
       runtime,
       session.model ?? null,
@@ -184,6 +223,11 @@ export function createAgentSessionRecord(input: {
       session.subagentTask ?? null,
       session.subagentType ?? null,
       session.subagentReadOnly ? 1 : 0,
+      session.worktree?.path ?? null,
+      session.worktree?.branch ?? null,
+      session.worktree?.baseBranch ?? null,
+      session.worktree?.baseSha ?? null,
+      session.worktree?.status ?? null,
       session.subagentWorktree?.path ?? null,
       session.subagentWorktree?.branch ?? null,
       session.subagentWorktree?.baseSha ?? null,
@@ -202,6 +246,39 @@ export function createAgentSessionRecord(input: {
 }
 
 export function updateAgentSessionWorktree(
+  sessionId: string,
+  worktree: SessionWorktreeInfo | undefined,
+): AgentSessionInfo | undefined {
+  const existing = getAgentSession(sessionId);
+  if (!existing) {
+    return undefined;
+  }
+
+  getDatabase()
+    .prepare(
+      `update agent_sessions
+       set worktree_path = ?,
+           worktree_branch = ?,
+           worktree_base_branch = ?,
+           worktree_base_sha = ?,
+           worktree_status = ?,
+           updated_at = ?
+       where id = ?`,
+    )
+    .run(
+      worktree?.path ?? null,
+      worktree?.branch ?? null,
+      worktree?.baseBranch ?? null,
+      worktree?.baseSha ?? null,
+      worktree?.status ?? null,
+      new Date().toISOString(),
+      sessionId,
+    );
+
+  return getAgentSession(sessionId);
+}
+
+export function updateAgentSessionSubagentWorktree(
   sessionId: string,
   worktree: SubagentWorktreeInfo | undefined,
 ): AgentSessionInfo | undefined {

--- a/apps/desktop/src/main/agent/pi-rpc-service.ts
+++ b/apps/desktop/src/main/agent/pi-rpc-service.ts
@@ -27,7 +27,7 @@ function stringifyLine(line: unknown): string {
 
 export function createPiRpcSession(
   window: BrowserWindowType,
-  input: { workspaceId: string; cwd: string; title: string },
+  input: { workspaceId: string; cwd: string; title: string; branch?: string },
 ): AgentSessionInfo {
   const info = createAgentSessionRecord({ ...input, runtime: "pi-rpc" });
   const sessionDir = join(app.getPath("userData"), "pi-sessions");

--- a/apps/desktop/src/main/agent/pi-sdk-runtime.ts
+++ b/apps/desktop/src/main/agent/pi-sdk-runtime.ts
@@ -52,8 +52,8 @@ import {
   listSubagentSessions,
   updateAgentSessionMetadata,
   updateAgentSessionStatus,
+  updateAgentSessionSubagentWorktree,
   updateAgentSessionTitle,
-  updateAgentSessionWorktree,
 } from "./agent-store";
 import { createCheckpoint } from "./checkpoint-service";
 import {
@@ -511,12 +511,14 @@ export class PiSdkRuntime implements AgentRuntime {
       workspaceId: input.workspaceId,
       cwd: input.cwd,
       title: input.title,
+      ...(input.branch !== undefined ? { branch: input.branch } : {}),
       runtime: "pi-sdk",
       ...(input.id !== undefined ? { id: input.id } : {}),
       ...(input.parentSessionId !== undefined ? { parentSessionId: input.parentSessionId } : {}),
       ...(input.subagentTask !== undefined ? { subagentTask: input.subagentTask } : {}),
       ...(input.subagentType !== undefined ? { subagentType: input.subagentType } : {}),
       ...(input.subagentReadOnly !== undefined ? { subagentReadOnly: input.subagentReadOnly } : {}),
+      ...(input.worktree !== undefined ? { worktree: input.worktree } : {}),
       ...(input.subagentWorktree !== undefined ? { subagentWorktree: input.subagentWorktree } : {}),
     };
     if (modelId !== undefined) {
@@ -1134,7 +1136,7 @@ export class PiSdkRuntime implements AgentRuntime {
           return;
         }
         const updated = await finishSubagentWorktree(session.subagentWorktree, input.task);
-        updateAgentSessionWorktree(session.id, updated);
+        updateAgentSessionSubagentWorktree(session.id, updated);
         if (!runFailed) {
           emit({
             type: "subagent.updated",

--- a/apps/desktop/src/main/agent/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime.ts
@@ -17,11 +17,13 @@ export type CreateAgentRuntimeInput = {
   workspaceId: string;
   cwd: string;
   title: string;
+  branch?: string;
   model?: string;
   parentSessionId?: string;
   subagentTask?: string;
   subagentType?: string;
   subagentReadOnly?: boolean;
+  worktree?: AgentSessionInfo["worktree"];
   subagentWorktree?: AgentSessionInfo["subagentWorktree"];
 };
 

--- a/apps/desktop/src/main/db/database.ts
+++ b/apps/desktop/src/main/db/database.ts
@@ -170,6 +170,7 @@ function migrate(db: DatabaseSync): void {
 
   addColumn(db, "agent_sessions", "runtime", "text not null default 'pi-sdk'");
   addColumn(db, "agent_sessions", "model", "text");
+  addColumn(db, "agent_sessions", "branch", "text");
   addColumn(db, "agent_sessions", "pi_session_id", "text");
   addColumn(db, "agent_sessions", "pi_session_file", "text");
   addColumn(
@@ -181,6 +182,11 @@ function migrate(db: DatabaseSync): void {
   addColumn(db, "agent_sessions", "subagent_task", "text");
   addColumn(db, "agent_sessions", "subagent_type", "text");
   addColumn(db, "agent_sessions", "subagent_readonly", "integer not null default 0");
+  addColumn(db, "agent_sessions", "worktree_path", "text");
+  addColumn(db, "agent_sessions", "worktree_branch", "text");
+  addColumn(db, "agent_sessions", "worktree_base_branch", "text");
+  addColumn(db, "agent_sessions", "worktree_base_sha", "text");
+  addColumn(db, "agent_sessions", "worktree_status", "text");
   addColumn(db, "agent_sessions", "subagent_worktree_path", "text");
   addColumn(db, "agent_sessions", "subagent_worktree_branch", "text");
   addColumn(db, "agent_sessions", "subagent_worktree_base_sha", "text");
@@ -196,18 +202,6 @@ function migrate(db: DatabaseSync): void {
   // Sidebar project pinning: pinned projects sort to the top (pinned_at breaks ties).
   addColumn(db, "workspaces", "pinned", "integer not null default 0");
   addColumn(db, "workspaces", "pinned_at", "text");
-  if (hasColumn(db, "agent_sessions", "worktree_path")) {
-    db.exec(`
-      update agent_sessions
-      set
-        cwd = coalesce(
-          (select root_path from workspaces where workspaces.id = agent_sessions.workspace_id),
-          cwd
-        ),
-        worktree_path = null
-      where worktree_path is not null
-    `);
-  }
   // PI session-tree leaf id captured right before each prompt — the exact
   // branch point used to rewind the conversation when the message is edited.
   // "root" marks an empty tree (first message); NULL marks legacy runs.

--- a/apps/desktop/src/main/git/git-service.test.ts
+++ b/apps/desktop/src/main/git/git-service.test.ts
@@ -9,8 +9,10 @@ import {
   abortSubagentWorktreeApply,
   applySubagentWorktree,
   checkoutBranch,
+  cleanupSessionWorktree,
   cleanupSubagentWorktree,
   commitOrPush,
+  createChatWorktree,
   createSubagentWorktree,
   discardFile,
   finishSubagentWorktree,
@@ -274,6 +276,55 @@ describe("git-service", () => {
     } finally {
       await rm(fresh, { recursive: true, force: true });
     }
+  });
+
+  it("creates a chat worktree from a selected local base branch", async () => {
+    const baseBranch = (await git(["branch", "--show-current"])).trim();
+    const worktree = await createChatWorktree(repo, {
+      sessionId: "abcdef12-3456-7890-abcd-ef1234567890",
+      baseBranch,
+    });
+
+    expect(worktree.path.replace(/\\/g, "/")).toContain(
+      `/.modus/worktrees/chat-${baseBranch}-abcdef12`,
+    );
+    expect(worktree.branch).toBe(`modus/chat/${baseBranch}-abcdef12`);
+    expect(worktree.baseBranch).toBe(baseBranch);
+    expect(worktree.status).toBe("active");
+    expect(existsSync(worktree.path)).toBe(true);
+
+    const cleaned = await cleanupSessionWorktree(repo, worktree);
+    expect(cleaned.status).toBe("cleaned");
+    expect(existsSync(worktree.path)).toBe(false);
+  });
+
+  it("creates a chat worktree directly from a remote-tracking base branch", async () => {
+    const baseSha = (await git(["rev-parse", "HEAD"])).trim();
+    await git(["update-ref", "refs/remotes/origin/feature/remote", baseSha]);
+
+    const worktree = await createChatWorktree(repo, {
+      sessionId: "abcdef12-3456-7890-abcd-ef1234567890",
+      baseBranch: "origin/feature/remote",
+      baseBranchRemote: true,
+    });
+
+    expect(worktree.baseBranch).toBe("origin/feature/remote");
+    expect(worktree.baseSha).toBe(baseSha);
+    expect((await execFileAsync("git", ["branch", "--show-current"], { cwd: worktree.path })).stdout.trim()).toBe(
+      worktree.branch,
+    );
+    expect((await git(["branch", "--list", "feature/remote"])).trim()).toBe("");
+
+    await cleanupSessionWorktree(repo, worktree);
+  });
+
+  it("rejects a chat worktree from a missing local base branch", async () => {
+    await expect(
+      createChatWorktree(repo, {
+        sessionId: "abcdef12-3456-7890-abcd-ef1234567890",
+        baseBranch: "origin/main",
+      }),
+    ).rejects.toThrow("not a local branch");
   });
 
   it("creates, finishes, applies, and cleans up a subagent worktree", async () => {

--- a/apps/desktop/src/main/git/git-service.ts
+++ b/apps/desktop/src/main/git/git-service.ts
@@ -13,6 +13,7 @@ import type {
   GitCommit,
   GitCommitResult,
   GitStatusSummary,
+  SessionWorktreeInfo,
   SubagentWorktreeInfo,
   WorkingChangeStats,
 } from "../../shared/contracts";
@@ -727,7 +728,7 @@ export async function checkoutBranch(
   return { kind: "ok", output: await git(cwd, ["switch", "--track", target]) };
 }
 
-function subagentSlug(value: string): string {
+function worktreeSlug(value: string): string {
   return (
     value
       .toLowerCase()
@@ -744,6 +745,10 @@ function assertManagedWorktreePath(repoRoot: string, worktreePath: string): void
   if (!rel || rel.startsWith("..") || isAbsolute(rel)) {
     throw new Error("Refusing to manage a worktree outside .modus/worktrees.");
   }
+}
+
+async function branchRefExists(cwd: string, ref: string): Promise<boolean> {
+  return Boolean(await gitSafe(cwd, ["show-ref", "--verify", ref]));
 }
 
 async function changedFilesBetween(cwd: string, base: string, target: string): Promise<string[]> {
@@ -767,6 +772,59 @@ async function excludeManagedWorktrees(commonGitDir: string): Promise<void> {
   }
 }
 
+export async function createChatWorktree(
+  cwd: string,
+  input: { sessionId: string; baseBranch: string; baseBranchRemote?: boolean },
+): Promise<SessionWorktreeInfo> {
+  const repo = resolveRepo(cwd);
+  if (!repo) {
+    throw new Error("Worktree isolation requires a Git repository.");
+  }
+  const baseRef = input.baseBranchRemote
+    ? `refs/remotes/${input.baseBranch}`
+    : `refs/heads/${input.baseBranch}`;
+  if (!(await branchRefExists(repo.root, baseRef))) {
+    throw new Error(
+      input.baseBranchRemote
+        ? `Remote base branch "${input.baseBranch}" does not exist.`
+        : `Base branch "${input.baseBranch}" is not a local branch.`,
+    );
+  }
+  const baseSha = await gitSafe(repo.root, [
+    "rev-parse",
+    "--verify",
+    `${baseRef}^{commit}`,
+  ]);
+  if (!baseSha) {
+    throw new Error("Worktree isolation requires an initial commit.");
+  }
+
+  const shortId = input.sessionId.replace(/[^a-f0-9]/gi, "").slice(0, 8);
+  const name = `${worktreeSlug(input.baseBranch)}-${shortId || input.sessionId.slice(0, 8)}`;
+  const worktreeRoot = join(repo.root, ".modus", "worktrees");
+  const worktreePath = join(worktreeRoot, `chat-${name}`);
+  const branch = `modus/chat/${name}`;
+  await mkdir(worktreeRoot, { recursive: true });
+  await excludeManagedWorktrees(repo.commonGitDir);
+  await git(repo.root, ["worktree", "add", "-b", branch, worktreePath, baseRef]);
+  return { path: worktreePath, branch, baseBranch: input.baseBranch, baseSha, status: "active" };
+}
+
+export async function cleanupSessionWorktree(
+  parentCwd: string,
+  worktree: SessionWorktreeInfo,
+): Promise<SessionWorktreeInfo> {
+  const repo = resolveRepo(parentCwd);
+  if (!repo) {
+    throw new Error("Worktree cleanup requires a Git repository.");
+  }
+  assertManagedWorktreePath(repo.root, worktree.path);
+  await git(repo.root, ["worktree", "remove", "--force", worktree.path]);
+  await gitSafe(repo.root, ["branch", "-D", worktree.branch]);
+  await rm(worktree.path, { recursive: true, force: true }).catch(() => undefined);
+  return { ...worktree, status: "cleaned" };
+}
+
 export async function createSubagentWorktree(
   cwd: string,
   input: { sessionId: string; name: string },
@@ -781,7 +839,7 @@ export async function createSubagentWorktree(
   }
 
   const shortId = input.sessionId.replace(/[^a-f0-9]/gi, "").slice(0, 8);
-  const name = `${subagentSlug(input.name)}-${shortId || input.sessionId.slice(0, 8)}`;
+  const name = `${worktreeSlug(input.name)}-${shortId || input.sessionId.slice(0, 8)}`;
   const worktreeRoot = join(repo.root, ".modus", "worktrees");
   const worktreePath = join(worktreeRoot, name);
   const branch = `modus/subagent/${name}`;

--- a/apps/desktop/src/main/ipc/channels.ts
+++ b/apps/desktop/src/main/ipc/channels.ts
@@ -27,6 +27,7 @@ export const IPC_CHANNELS = {
   agentApplySubagentWorktree: "agent:apply-subagent-worktree",
   agentAbortSubagentWorktreeApply: "agent:abort-subagent-worktree-apply",
   agentCleanupSubagentWorktree: "agent:cleanup-subagent-worktree",
+  agentCleanupSessionWorktree: "agent:cleanup-session-worktree",
   agentSetModel: "agent:set-model",
   agentCycleModel: "agent:cycle-model",
   agentEvent: "agent:event",

--- a/apps/desktop/src/main/ipc/register-app-ipc.ts
+++ b/apps/desktop/src/main/ipc/register-app-ipc.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { isAbsolute, resolve, sep } from "node:path";
 import {
   app,
@@ -14,6 +15,7 @@ import {
   listAgentSessions,
   listArchivedAgentSessions,
   setAgentSessionPinned,
+  updateAgentSessionSubagentWorktree,
   updateAgentSessionWorktree,
 } from "../agent/agent-store";
 import {
@@ -26,12 +28,12 @@ import {
   configureProvider,
   deleteCustomProvider,
   disconnectProvider,
-  getProviderAuthState,
   getCustomProviderConfig,
   getModelSettings,
+  getProviderAuthState,
   getProviderDetail,
-  listProviderConnectionMethods,
   listModels,
+  listProviderConnectionMethods,
   refreshRemoteModelCatalog,
   respondProviderAuth,
   setDefaultModel,
@@ -78,8 +80,10 @@ import {
   abortSubagentWorktreeApply,
   applySubagentWorktree,
   checkoutBranch,
+  cleanupSessionWorktree,
   cleanupSubagentWorktree,
   commitOrPush,
+  createChatWorktree,
   discardFile,
   getChangeStatsSince,
   getStatusSummary,
@@ -148,6 +152,7 @@ import {
 import { upsertWorkspace } from "../workspace/workspace-store";
 import { IPC_CHANNELS } from "./channels";
 import {
+  agentCleanupSessionWorktreeSchema,
   agentCreateSchema,
   agentCycleModelSchema,
   agentListSchema,
@@ -188,11 +193,11 @@ import {
   parseIpcInput,
   permissionDecideSchema,
   personalizationSaveSchema,
+  processKillSchema,
+  processListSchema,
   providerAuthOperationSchema,
   providerAuthResponseSchema,
   providerAuthStartSchema,
-  processKillSchema,
-  processListSchema,
   questionRespondSchema,
   reviewStartSchema,
   sessionIdSchema,
@@ -351,12 +356,49 @@ export function registerAppIpc({
   ipcMain.handle(IPC_CHANNELS.agentCreate, async (event, input) => {
     assertTrustedSender(event);
     const parsed = parseIpcInput(agentCreateSchema, input, IPC_CHANNELS.agentCreate);
-    return await getAgentRuntime().create(getSenderWindow(event), {
+    const createInput = {
       workspaceId: parsed.workspaceId,
       cwd: parsed.cwd,
       title: parsed.title,
       ...(parsed.model !== undefined ? { model: parsed.model } : {}),
+    };
+    const baseBranch = parsed.baseBranch;
+    if (parsed.draftScope === "local") {
+      if (!baseBranch) {
+        throw new Error("Base branch is required for local sessions.");
+      }
+      const result = await checkoutBranch(parsed.cwd, baseBranch);
+      return await getAgentRuntime().create(getSenderWindow(event), {
+        ...createInput,
+        branch: baseBranch,
+        ...(result.kind === "worktree" && result.worktreePath ? { cwd: result.worktreePath } : {}),
+      });
+    }
+    if (parsed.draftScope !== "worktree") {
+      return await getAgentRuntime().create(getSenderWindow(event), createInput);
+    }
+
+    const sessionId = randomUUID();
+    if (!baseBranch) {
+      throw new Error("Base branch is required for worktree sessions.");
+    }
+    const worktree = await createChatWorktree(parsed.cwd, {
+      sessionId,
+      baseBranch,
+      ...(parsed.baseBranchRemote ? { baseBranchRemote: true } : {}),
     });
+    try {
+      return await getAgentRuntime().create(getSenderWindow(event), {
+        ...createInput,
+        id: sessionId,
+        cwd: worktree.path,
+        branch: worktree.branch,
+        worktree,
+      });
+    } catch (error) {
+      await cleanupSessionWorktree(parsed.cwd, worktree).catch(() => undefined);
+      throw error;
+    }
   });
 
   ipcMain.handle(IPC_CHANNELS.agentList, (event, input) => {
@@ -462,7 +504,7 @@ export function registerAppIpc({
       throw new Error("Parent session not found.");
     }
     const worktree = await applySubagentWorktree(parent.cwd, child.subagentWorktree);
-    const updated = updateAgentSessionWorktree(child.id, worktree) ?? child;
+    const updated = updateAgentSessionSubagentWorktree(child.id, worktree) ?? child;
     emitGitEvent({ cwd: parent.cwd, kind: "index" });
     return updated;
   });
@@ -486,7 +528,7 @@ export function registerAppIpc({
       throw new Error("Parent session not found.");
     }
     const worktree = await abortSubagentWorktreeApply(parent.cwd, child.subagentWorktree);
-    const updated = updateAgentSessionWorktree(child.id, worktree) ?? child;
+    const updated = updateAgentSessionSubagentWorktree(child.id, worktree) ?? child;
     emitGitEvent({ cwd: parent.cwd, kind: "index" });
     return updated;
   });
@@ -506,8 +548,25 @@ export function registerAppIpc({
       throw new Error("Parent session not found.");
     }
     const worktree = await cleanupSubagentWorktree(parent.cwd, child.subagentWorktree);
-    const updated = updateAgentSessionWorktree(child.id, worktree) ?? child;
+    const updated = updateAgentSessionSubagentWorktree(child.id, worktree) ?? child;
     emitGitEvent({ cwd: parent.cwd, kind: "refs" });
+    return updated;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.agentCleanupSessionWorktree, async (event, input) => {
+    assertTrustedSender(event);
+    const parsed = parseIpcInput(
+      agentCleanupSessionWorktreeSchema,
+      input,
+      IPC_CHANNELS.agentCleanupSessionWorktree,
+    );
+    const session = getAgentSession(parsed.sessionId);
+    if (!session?.worktree) {
+      throw new Error("Session worktree not found.");
+    }
+    const worktree = await cleanupSessionWorktree(parsed.cwd, session.worktree);
+    const updated = updateAgentSessionWorktree(session.id, worktree) ?? session;
+    emitGitEvent({ cwd: parsed.cwd, kind: "refs" });
     return updated;
   });
 

--- a/apps/desktop/src/main/ipc/schemas.ts
+++ b/apps/desktop/src/main/ipc/schemas.ts
@@ -20,11 +20,28 @@ const modelCostSchema = z
   })
   .optional();
 
-export const agentCreateSchema = z.object({
-  workspaceId: nonEmptyString,
+export const agentCreateSchema = z
+  .object({
+    workspaceId: nonEmptyString,
+    cwd: nonEmptyString,
+    title: nonEmptyString,
+    model: optionalNonEmptyString,
+    draftScope: z.enum(["local", "worktree"]).optional(),
+    baseBranch: optionalNonEmptyString,
+    baseBranchRemote: z.boolean().optional(),
+  })
+  .refine((input) => input.draftScope === undefined || input.baseBranch !== undefined, {
+    message: "baseBranch is required when selecting a chat branch.",
+    path: ["baseBranch"],
+  })
+  .refine((input) => input.draftScope !== "local" || !input.baseBranchRemote, {
+    message: "Local sessions require a local branch.",
+    path: ["baseBranchRemote"],
+  });
+
+export const agentCleanupSessionWorktreeSchema = z.object({
+  sessionId: nonEmptyString,
   cwd: nonEmptyString,
-  title: nonEmptyString,
-  model: optionalNonEmptyString,
 });
 
 export const workspacePinSchema = z.object({

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -42,6 +42,7 @@ const api: ModusApi = {
       ipcRenderer.invoke("agent:abort-subagent-worktree-apply", sessionId),
     cleanupSubagentWorktree: (sessionId) =>
       ipcRenderer.invoke("agent:cleanup-subagent-worktree", sessionId),
+    cleanupSessionWorktree: (input) => ipcRenderer.invoke("agent:cleanup-session-worktree", input),
     setModel: (input) => ipcRenderer.invoke("agent:set-model", input),
     cycleModel: (input) => ipcRenderer.invoke("agent:cycle-model", input),
     onEvent: (callback) => {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -36,8 +36,6 @@ import type {
   McpServerInfo,
   McpServerUpsertInput,
   ModelInfo,
-  ProviderAuthOperationState,
-  ProviderConnectionMethod,
   ModelProviderDetail,
   ModelSettingsState,
   PermissionAction,
@@ -45,6 +43,8 @@ import type {
   PersonalizationState,
   PromptDelivery,
   PromptImageAttachment,
+  ProviderAuthOperationState,
+  ProviderConnectionMethod,
   QuestionAnswer,
   QuestionResponse,
   RawMcpEntry,
@@ -119,6 +119,9 @@ export type ModusApi = {
       cwd: string;
       title: string;
       model?: string;
+      draftScope?: "local" | "worktree";
+      baseBranch?: string;
+      baseBranchRemote?: boolean;
     }): Promise<AgentSessionInfo>;
     list(input?: { includeSessionId?: string }): Promise<AgentSessionInfo[]>;
     listArchived(workspaceId: string): Promise<AgentSessionInfo[]>;
@@ -156,6 +159,7 @@ export type ModusApi = {
     applySubagentWorktree(sessionId: string): Promise<AgentSessionInfo>;
     abortSubagentWorktreeApply(sessionId: string): Promise<AgentSessionInfo>;
     cleanupSubagentWorktree(sessionId: string): Promise<AgentSessionInfo>;
+    cleanupSessionWorktree(input: { sessionId: string; cwd: string }): Promise<AgentSessionInfo>;
     setModel(input: {
       sessionId: string;
       model: string;

--- a/apps/desktop/src/renderer/src/app/App.tsx
+++ b/apps/desktop/src/renderer/src/app/App.tsx
@@ -36,6 +36,7 @@ import type {
   ContextItem,
   ContextUsageInfo,
   FileDiff,
+  GitBranchSummary,
   ModelInfo,
   ModelSettingsState,
   PlanRef,
@@ -66,7 +67,6 @@ import type {
   ChatPaneHandle,
 } from "../features/agent/ChatPane";
 import { Composer, createEmptyComposerDraft } from "../features/composer/Composer";
-import { BranchSwitcher } from "../features/git/BranchSwitcher";
 import { INSPECTOR_MIN_WIDTH } from "../features/inspector/inspector-layout";
 import { cn } from "../lib/cn";
 import { useGitBranch } from "../lib/useGitBranch";
@@ -120,6 +120,9 @@ export function App() {
   // Composer mode for the hero (new-chat) screen — controlled so the "Plan New
   // Idea" pill can start a session straight in plan mode.
   const [heroMode, setHeroMode] = useState<AgentMode>("build");
+  const [heroScope, setHeroScope] = useState<"local" | "worktree">("local");
+  const [heroBaseBranch, setHeroBaseBranch] = useState<string | undefined>();
+  const [heroBaseBranchRemote, setHeroBaseBranchRemote] = useState(false);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [model, setModel] = useState("");
   const [modelSettings, setModelSettings] = useState<ModelSettingsState | null>(null);
@@ -411,11 +414,17 @@ export function App() {
       return;
     }
     setActiveWorkspace(workspace);
+    setHeroScope("local");
+    setHeroBaseBranch(undefined);
+    setHeroBaseBranchRemote(false);
     setWorkspaces(await window.modus.workspace.list());
     await refreshSessions();
   }
 
-  async function createSession(workspace: WorkspaceInfo | null): Promise<AgentSessionInfo | null> {
+  async function createSession(
+    workspace: WorkspaceInfo | null,
+    target: { scope: "local" | "worktree"; baseBranch?: string; baseBranchRemote?: boolean },
+  ): Promise<AgentSessionInfo | null> {
     if (!workspace) {
       return null;
     }
@@ -424,10 +433,17 @@ export function App() {
       setSessionCreateError("No model is configured. Connect a provider in Settings first.");
       return null;
     }
+    if (!target.baseBranch) {
+      setSessionCreateError("Select a branch before creating a chat.");
+      return null;
+    }
     try {
       const session = await window.modus.agent.create({
         workspaceId: workspace.id,
         cwd: workspace.rootPath,
+        draftScope: target.scope,
+        baseBranch: target.baseBranch,
+        ...(target.baseBranchRemote ? { baseBranchRemote: true } : {}),
         ...(model ? { model } : {}),
         title: "New chat",
       });
@@ -507,6 +523,8 @@ export function App() {
   function openNewChat(workspace?: WorkspaceInfo | null): void {
     if (workspace !== undefined) {
       setActiveWorkspace(workspace);
+      setHeroScope("local");
+      setHeroBaseBranch(undefined);
     }
     setSessionCreateError(undefined);
     setSettingsOpen(false);
@@ -548,8 +566,15 @@ export function App() {
     await refreshSessions();
   }
 
-  async function deleteSession(session: AgentSessionInfo): Promise<void> {
+  async function deleteSession(session: AgentSessionInfo, cleanupWorktree = false): Promise<void> {
     try {
+      if (cleanupWorktree && session.worktree) {
+        const workspace = workspaceById.get(session.workspaceId);
+        await window.modus.agent.cleanupSessionWorktree({
+          sessionId: session.id,
+          cwd: workspace?.rootPath ?? session.cwd,
+        });
+      }
       await window.modus.agent.delete(session.id);
     } catch (error) {
       setSessionCreateError(error instanceof Error ? error.message : String(error));
@@ -613,7 +638,12 @@ export function App() {
     if (!message.trim()) {
       return;
     }
-    const session = await createSession(activeWorkspace);
+    const target = {
+      scope: heroScope,
+      ...(heroBaseBranch ? { baseBranch: heroBaseBranch } : {}),
+      ...(heroBaseBranchRemote ? { baseBranchRemote: true } : {}),
+    };
+    const session = await createSession(activeWorkspace, target);
     if (!session) {
       return;
     }
@@ -813,7 +843,9 @@ export function App() {
                       agentSessions={rootSessions}
                       canCreateSession={canCreateSession}
                       onArchiveSession={(session) => void archiveSession(session)}
-                      onDeleteSession={(session) => void deleteSession(session)}
+                      onDeleteSession={(session, cleanupWorktree) =>
+                        void deleteSession(session, cleanupWorktree)
+                      }
                       onListArchivedSessions={(workspaceId) =>
                         window.modus.agent.listArchived(workspaceId)
                       }
@@ -946,9 +978,21 @@ export function App() {
                                 footer={
                                   <HeroEnvironmentTray
                                     activeWorkspace={activeWorkspace}
-                                    branch={branch}
-                                    cwd={activeCwd}
-                                    onError={setSessionCreateError}
+                                    cwd={activeWorkspace?.rootPath}
+                                    scope={heroScope}
+                                    baseBranch={heroBaseBranch}
+                                    baseBranchRemote={heroBaseBranchRemote}
+                                    onScopeChange={(scope) => {
+                                      setHeroScope(scope);
+                                      if (scope === "local" && heroBaseBranchRemote) {
+                                        setHeroBaseBranchRemote(false);
+                                        setHeroBaseBranch(undefined);
+                                      }
+                                    }}
+                                    onBaseBranchChange={(branch, remote = false) => {
+                                      setHeroBaseBranch(branch);
+                                      setHeroBaseBranchRemote(remote);
+                                    }}
                                     onOpenFolder={() => void openWorkspace()}
                                     onSelectWorkspace={openNewChat}
                                     workspaces={workspaces}
@@ -1162,21 +1206,69 @@ const HERO_ENVIRONMENT_TRIGGER_CLASS =
 
 function HeroEnvironmentTray({
   activeWorkspace,
-  branch,
   cwd,
   workspaces,
+  scope,
+  baseBranch,
+  baseBranchRemote,
   onSelectWorkspace,
   onOpenFolder,
-  onError,
+  onScopeChange,
+  onBaseBranchChange,
 }: {
   activeWorkspace: WorkspaceInfo | null;
-  branch: string | undefined;
   cwd: string | undefined;
   workspaces: WorkspaceInfo[];
+  scope: "local" | "worktree";
+  baseBranch: string | undefined;
+  baseBranchRemote: boolean;
   onSelectWorkspace(workspace: WorkspaceInfo): void;
   onOpenFolder(): void;
-  onError(message: string): void;
+  onScopeChange(scope: "local" | "worktree"): void;
+  onBaseBranchChange(branch: string | undefined, remote?: boolean): void;
 }) {
+  const [branches, setBranches] = useState<GitBranchSummary>({ local: [], remote: [] });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!cwd) {
+      setBranches({ local: [], remote: [] });
+      return undefined;
+    }
+    void window.modus.git
+      .branches(cwd)
+      .then((next: GitBranchSummary) => {
+        if (!cancelled) {
+          setBranches(next);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setBranches({ local: [], remote: [] });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd]);
+
+  const localBranches = branches.local;
+  const visibleRemotes = scope === "worktree" ? branches.remote : [];
+  const remoteGroups = visibleRemotes.reduce<Record<string, typeof visibleRemotes>>((groups, branch) => {
+    const slash = branch.name.indexOf("/");
+    if (slash <= 0 || slash === branch.name.length - 1) return groups;
+    const remote = branch.name.slice(0, slash);
+    (groups[remote] ??= []).push(branch);
+    return groups;
+  }, {});
+  const selectedBaseBranch = baseBranch ?? branches.current ?? localBranches[0]?.name;
+
+  useEffect(() => {
+    if (!baseBranch && selectedBaseBranch) {
+      onBaseBranchChange(selectedBaseBranch, false);
+    }
+  }, [baseBranch, onBaseBranchChange, selectedBaseBranch]);
+
   return (
     <div className="app-no-drag flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
       <WorkspaceMenu
@@ -1185,13 +1277,89 @@ function HeroEnvironmentTray({
         onSelect={onSelectWorkspace}
         workspaces={workspaces}
       />
-      <BranchSwitcher cwd={cwd} onError={onError} triggerClassName={HERO_ENVIRONMENT_TRIGGER_CLASS}>
-        <span className="toolbar-icon">
-          <IconGitBranch size={18} stroke={1.7} />
-        </span>
-        <span className="max-w-40 truncate">{branch ?? "No branch"}</span>
-        <IconChevronDown className="toolbar-icon" size={13} stroke={2} />
-      </BranchSwitcher>
+      <Menu.Root>
+        <Menu.Trigger className={HERO_ENVIRONMENT_TRIGGER_CLASS}>
+          <span>{scope === "local" ? "Local" : "Worktree"}</span>
+          <IconChevronDown className="toolbar-icon" size={13} stroke={2} />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner align="start" side="bottom" sideOffset={6}>
+            <Menu.Popup className="min-w-28 rounded-lg border border-hairline bg-elevated p-1 shadow-popup">
+              {[
+                { label: "Local", value: "local" as const },
+                { label: "Worktree", value: "worktree" as const },
+              ].map((option) => (
+                <Menu.Item
+                  className="flex h-8 cursor-default items-center gap-2 rounded-md px-2 text-sm text-fg-muted outline-none select-none data-highlighted:bg-hover data-highlighted:text-fg"
+                  closeOnClick
+                  key={option.value}
+                  onClick={() => onScopeChange(option.value)}
+                >
+                  <span className="flex size-4 shrink-0 items-center justify-center text-accent">
+                    {scope === option.value ? <IconCheck size={13} stroke={2} /> : null}
+                  </span>
+                  <span>{option.label}</span>
+                </Menu.Item>
+              ))}
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+      <Menu.Root>
+        <Menu.Trigger
+          className={HERO_ENVIRONMENT_TRIGGER_CLASS}
+          disabled={localBranches.length === 0}
+        >
+          <span className="toolbar-icon">
+            <IconGitBranch size={18} stroke={1.7} />
+          </span>
+          <span className="max-w-40 truncate">{selectedBaseBranch ?? "Select branch"}</span>
+          <IconChevronDown className="toolbar-icon" size={13} stroke={2} />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner align="start" side="bottom" sideOffset={6}>
+            <Menu.Popup className="scroll-thin origin-(--transform-origin) max-h-[360px] min-w-[260px] overflow-y-auto rounded-lg border border-hairline bg-elevated p-1 shadow-popup">
+              <div className="px-2.5 pt-2 pb-1 text-2xs text-fg-faint">Local</div>
+              {localBranches.map((item) => (
+                <Menu.Item
+                  className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-1.5 text-fg text-sm outline-none transition-colors select-none data-highlighted:bg-hover"
+                  closeOnClick
+                  key={`local:${item.name}`}
+                  onClick={() => onBaseBranchChange(item.name, false)}
+                >
+                  <span className="flex size-4 shrink-0 items-center justify-center text-accent">
+                    {!baseBranchRemote && item.name === selectedBaseBranch ? <IconCheck size={14} stroke={2} /> : null}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                  {item.current ? <span className="text-fg-faint text-xs">current</span> : null}
+                  {item.worktreePath ? <span className="text-fg-faint text-xs">worktree</span> : null}
+                </Menu.Item>
+              ))}
+              {Object.entries(remoteGroups).sort(([a], [b]) => a.localeCompare(b)).map(([remote, items]) => (
+                <div key={remote}>
+                  <div className="mt-1 border-hairline border-t px-2.5 pt-2 pb-1 text-2xs text-fg-faint">{remote}</div>
+                  {items.map((item) => {
+                    const displayName = item.name.slice(remote.length + 1);
+                    return (
+                      <Menu.Item
+                        className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-1.5 text-fg text-sm outline-none transition-colors select-none data-highlighted:bg-hover"
+                        closeOnClick
+                        key={`remote:${item.name}`}
+                        onClick={() => onBaseBranchChange(item.name, true)}
+                      >
+                        <span className="flex size-4 shrink-0 items-center justify-center text-accent">
+                          {baseBranchRemote && item.name === selectedBaseBranch ? <IconCheck size={14} stroke={2} /> : null}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate">{displayName}</span>
+                      </Menu.Item>
+                    );
+                  })}
+                </div>
+              ))}
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { Dialog } from "@base-ui/react/dialog";
 import { Menu } from "@base-ui/react/menu";
 import {
   IconArchive,
@@ -9,8 +10,10 @@ import {
   IconFolder,
   IconFolderOpen,
   IconFolderPlus,
+  IconGitBranch,
   IconGridDots,
   IconLayoutSidebar,
+  IconMessage,
   IconPencil,
   IconPin,
   IconPinnedOff,
@@ -23,6 +26,7 @@ import { animate, m, useMotionValue } from "motion/react";
 import {
   type MouseEvent,
   type PointerEvent,
+  type ReactElement,
   type ReactNode,
   useEffect,
   useRef,
@@ -32,6 +36,7 @@ import type { AgentSessionInfo, WorkspaceInfo } from "../../../shared/contracts"
 import type { SessionActivity } from "../features/agent/agentEventHub";
 import { SessionStatusDot } from "../features/agent/SessionStatusDot";
 import { cn } from "../lib/cn";
+import { Tooltip } from "./ui/Tooltip";
 import { CollapsibleMotion } from "./ui/CollapsibleMotion";
 import { ToolbarButton } from "./ui/ToolbarButton";
 
@@ -56,7 +61,7 @@ type SidebarProps = {
   onPinSession(session: AgentSessionInfo, pinned: boolean): void;
   onArchiveSession(session: AgentSessionInfo): void;
   onRestoreSession(session: AgentSessionInfo): void;
-  onDeleteSession(session: AgentSessionInfo): void;
+  onDeleteSession(session: AgentSessionInfo, cleanupWorktree?: boolean): void;
   onListArchivedSessions(workspaceId: string): Promise<AgentSessionInfo[]>;
   onPinProject(id: string, pinned: boolean): void;
   onRenameProject(id: string, displayName: string): void;
@@ -306,7 +311,7 @@ function WorkspaceItem({
   onPinSession(session: AgentSessionInfo, pinned: boolean): void;
   onArchiveSession(session: AgentSessionInfo): void;
   onRestoreSession(session: AgentSessionInfo): void;
-  onDeleteSession(session: AgentSessionInfo): void;
+  onDeleteSession(session: AgentSessionInfo, cleanupWorktree?: boolean): void;
   onListArchivedSessions(workspaceId: string): Promise<AgentSessionInfo[]>;
   renaming: boolean;
   onStartRename(): void;
@@ -367,18 +372,13 @@ function WorkspaceItem({
               event.stopPropagation();
               onArchiveSession(session);
             }}
-            onDelete={(event) => {
-              event.stopPropagation();
-              onDeleteSession(session);
-            }}
+            onDelete={(cleanupWorktree) => onDeleteSession(session, cleanupWorktree)}
             onPin={(event) => {
               event.stopPropagation();
               onPinSession(session, !session.pinnedAt);
             }}
             onSelect={() => onSelectSession(session)}
-            pinned={Boolean(session.pinnedAt)}
-            title={session.title}
-            updatedAt={session.updatedAt}
+            session={session}
           />
         ))}
         <CollapsibleMotion open={archivedOpen} preset="default">
@@ -409,31 +409,76 @@ function WorkspaceItem({
   );
 }
 
+function SessionRowTooltip({
+  session,
+  children,
+}: {
+  session: AgentSessionInfo;
+  children: ReactElement;
+}) {
+  return (
+    <Tooltip
+      content={<SessionHoverDetails session={session} />}
+      motion="fade"
+      side="right"
+      sideOffset={8}
+    >
+      {children}
+    </Tooltip>
+  );
+}
+
+function SessionHoverDetails({ session }: { session: AgentSessionInfo }) {
+  const worktree = session.worktree;
+  const branch = session.branch ?? worktree?.branch;
+  const folder = worktree?.path ?? session.cwd;
+  return (
+    <div className="w-[280px] space-y-1.5 py-0.5">
+      <div className="flex min-w-0 items-center gap-2 text-fg">
+        <IconMessage className="shrink-0 text-fg-muted" size={13} stroke={1.8} />
+        <span className="min-w-0 truncate" title={session.title}>
+          {session.title}
+        </span>
+      </div>
+      <div className="flex min-w-0 items-center gap-2 text-fg-muted">
+        <IconGitBranch className="shrink-0 text-fg-faint" size={13} stroke={1.8} />
+        <span className="min-w-0 truncate font-mono text-2xs" title={branch}>
+          {branch ?? "Unknown branch"}
+        </span>
+      </div>
+      <div className="flex min-w-0 items-center gap-2 text-fg-muted">
+        <IconFolder className="shrink-0 text-fg-faint" size={13} stroke={1.8} />
+        <span className="min-w-0 truncate font-mono text-2xs" title={folder}>
+          {folder}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function SessionRow({
-  title,
-  updatedAt,
+  session,
   isActive,
-  pinned,
   activity,
   onSelect,
   onPin,
   onArchive,
   onDelete,
 }: {
-  title: string;
-  updatedAt: string;
+  session: AgentSessionInfo;
   isActive: boolean;
-  pinned: boolean;
   activity: SessionActivity | undefined;
   onSelect(): void;
   onPin(event: MouseEvent<HTMLButtonElement>): void;
   onArchive(event: MouseEvent<HTMLButtonElement>): void;
-  onDelete(event: MouseEvent<HTMLButtonElement>): void;
+  onDelete(cleanupWorktree?: boolean): void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [worktreeDeleteOpen, setWorktreeDeleteOpen] = useState(false);
   const hasStatus = Boolean(
     activity && (activity.running || activity.needsInput || activity.unread || activity.failed),
   );
+  const worktree = session.worktree;
   useEffect(() => {
     if (!confirmDelete) {
       return;
@@ -442,68 +487,141 @@ function SessionRow({
     return () => window.clearTimeout(timeout);
   }, [confirmDelete]);
 
+  function confirmSessionDelete(): void {
+    setConfirmDelete(false);
+    if (worktree) {
+      setWorktreeDeleteOpen(true);
+      return;
+    }
+    onDelete();
+  }
+
   return (
-    <m.div
-      className={cn(
-        "group flex h-[34px] w-full items-center rounded-lg pr-1 pl-[30px] text-sm font-normal transition-colors hover:bg-hover",
-        isActive ? "bg-active text-fg" : "text-fg-muted hover:text-fg",
-      )}
-      layout
-      onBlurCapture={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setConfirmDelete(false);
-        }
-      }}
-      onMouseLeave={() => setConfirmDelete(false)}
-      transition={{ duration: 0.14, ease: "easeOut" }}
-    >
-      <button
-        className="flex min-w-0 flex-1 items-center gap-2 py-2 pr-1 pl-3 text-left"
-        onClick={onSelect}
-        title="Open"
-        type="button"
+    <>
+      <SessionRowTooltip session={session}>
+        <m.div
+        className={cn(
+          "group flex h-[34px] w-full items-center rounded-lg pr-1 pl-[30px] text-sm font-normal transition-colors hover:bg-hover",
+          isActive ? "bg-active text-fg" : "text-fg-muted hover:text-fg",
+        )}
+        layout
+        onBlurCapture={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) {
+            setConfirmDelete(false);
+          }
+        }}
+        onMouseLeave={() => setConfirmDelete(false)}
+        transition={{ duration: 0.14, ease: "easeOut" }}
       >
-        <span className="min-w-0 flex-1 truncate">{title}</span>
-        <span
-          className={cn(
-            "shrink-0 text-xs font-normal text-fg-faint group-hover:hidden",
-            hasStatus ? "ml-1" : "ml-2",
-          )}
-        >
-          {formatRelativeTime(updatedAt)}
-        </span>
-        {hasStatus ? (
-          <SessionStatusDot activity={activity} className="ml-1 group-hover:hidden" />
-        ) : null}
-      </button>
-      <span className="ml-1 hidden shrink-0 items-center group-hover:flex group-focus-within:flex">
-        <IconButton label={pinned ? "Unpin chat" : "Pin chat"} onClick={onPin}>
-          {pinned ? <IconPinnedOff size={14} stroke={1.8} /> : <IconPin size={14} stroke={1.8} />}
-        </IconButton>
-        <IconButton label="Archive" onClick={onArchive}>
-          <IconArchive size={14} stroke={1.8} />
-        </IconButton>
-        {confirmDelete ? (
-          <button
-            className="ml-0.5 h-6 rounded-md px-1.5 text-2xs text-danger transition-colors hover:bg-active"
-            onClick={onDelete}
+        <button
+            className="flex min-w-0 flex-1 items-center gap-2 py-2 pr-1 pl-3 text-left"
+            onClick={onSelect}
+            title="Open"
             type="button"
           >
-            Confirm
-          </button>
-        ) : (
-          <IconButton
-            label="Delete"
-            onClick={(event) => {
-              event.stopPropagation();
-              setConfirmDelete(true);
-            }}
-          >
-            <IconTrash size={14} stroke={1.8} />
+            <span className="min-w-0 flex-1 truncate">{session.title}</span>
+            {worktree ? (
+              <span className="flex min-w-0 shrink items-center gap-1 text-2xs text-accent">
+                <IconGitBranch className="shrink-0" size={12} stroke={1.8} />
+                <span className="rounded bg-accent/10 px-1 py-0.5">worktree</span>
+              </span>
+            ) : null}
+            <span
+              className={cn(
+                "shrink-0 text-xs font-normal text-fg-faint group-hover:hidden",
+                hasStatus ? "ml-1" : "ml-2",
+              )}
+            >
+              {formatRelativeTime(session.updatedAt)}
+            </span>
+            {hasStatus ? (
+              <SessionStatusDot activity={activity} className="ml-1 group-hover:hidden" />
+            ) : null}
+        </button>
+        <span className="ml-1 hidden shrink-0 items-center group-hover:flex group-focus-within:flex">
+          <IconButton label={session.pinnedAt ? "Unpin chat" : "Pin chat"} onClick={onPin}>
+            {session.pinnedAt ? (
+              <IconPinnedOff size={14} stroke={1.8} />
+            ) : (
+              <IconPin size={14} stroke={1.8} />
+            )}
           </IconButton>
-        )}
-      </span>
-    </m.div>
+          <IconButton label="Archive" onClick={onArchive}>
+            <IconArchive size={14} stroke={1.8} />
+          </IconButton>
+          {confirmDelete ? (
+            <button
+              className="ml-0.5 h-6 rounded-md px-1.5 text-2xs text-danger transition-colors hover:bg-active"
+              onClick={confirmSessionDelete}
+              type="button"
+            >
+              Confirm
+            </button>
+          ) : (
+            <IconButton
+              label="Delete"
+              onClick={(event) => {
+                event.stopPropagation();
+                setConfirmDelete(true);
+              }}
+            >
+              <IconTrash size={14} stroke={1.8} />
+            </IconButton>
+          )}
+        </span>
+        </m.div>
+      </SessionRowTooltip>
+      {worktree ? (
+        <Dialog.Root onOpenChange={setWorktreeDeleteOpen} open={worktreeDeleteOpen}>
+          <Dialog.Portal>
+            <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50" />
+            <Dialog.Popup className="-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-50 w-[min(420px,calc(100vw-2rem))] rounded-xl border border-hairline bg-elevated p-4 shadow-popup outline-none">
+              <Dialog.Title className="text-sm font-medium text-fg">
+                Delete worktree chat?
+              </Dialog.Title>
+              <Dialog.Description className="mt-2 text-sm text-fg-muted">
+                <span className="block truncate font-mono text-xs text-fg">{worktree.branch}</span>
+                <span className="mt-1 block truncate font-mono text-2xs text-fg-faint">
+                  {worktree.path}
+                </span>
+              </Dialog.Description>
+              <p className="mt-3 text-xs text-fg-faint">
+                Clean up removes this worktree, its branch, and uncommitted changes.
+              </p>
+              <div className="mt-4 flex justify-end gap-2">
+                <button
+                  className="rounded-md px-3 py-1.5 text-sm text-fg-muted hover:bg-hover"
+                  onClick={() => setWorktreeDeleteOpen(false)}
+                  type="button"
+                >
+                  Cancel
+                </button>
+                <button
+                  className="rounded-md border border-hairline px-3 py-1.5 text-sm text-fg hover:bg-hover"
+                  onClick={() => {
+                    setWorktreeDeleteOpen(false);
+                    onDelete(false);
+                  }}
+                  type="button"
+                >
+                  Keep worktree
+                </button>
+                <button
+                  className="rounded-md bg-danger px-3 py-1.5 text-sm text-white hover:bg-danger/90"
+                  onClick={() => {
+                    setWorktreeDeleteOpen(false);
+                    onDelete(true);
+                  }}
+                  type="button"
+                >
+                  Clean up
+                </button>
+              </div>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>
+      ) : null}
+    </>
   );
 }
 

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -13,6 +13,8 @@ export type AgentSessionInfo = {
   workspaceId: string;
   title: string;
   cwd: string;
+  /** Branch checked out for this session, when known. */
+  branch?: string;
   status: "starting" | AgentRunStatus | "idle" | "exited" | "error";
   runtime?: "pi-sdk" | "pi-rpc";
   model?: string;
@@ -22,6 +24,7 @@ export type AgentSessionInfo = {
   subagentTask?: string;
   subagentType?: string;
   subagentReadOnly?: boolean;
+  worktree?: SessionWorktreeInfo;
   subagentWorktree?: SubagentWorktreeInfo;
   pinnedAt?: string;
   archivedAt?: string;
@@ -30,6 +33,14 @@ export type AgentSessionInfo = {
 };
 
 export type AgentRunStatus = "running" | "completed" | "failed" | "blocked" | "cancelled";
+
+export type SessionWorktreeInfo = {
+  path: string;
+  branch: string;
+  baseBranch: string;
+  baseSha: string;
+  status: "active" | "cleaned";
+};
 
 export type SubagentWorktreeInfo = {
   path: string;


### PR DESCRIPTION
## Summary

Adds flexible chat environment selection.

Users can now:

- Start a chat on a selected local branch.
- Create an isolated worktree chat from a local branch.
- Create a worktree chat from a remote-tracking branch.
- See the session branch and folder path in the Sidebar.

The `Local / Worktree` selector follows the existing workspace and branch selector UI patterns.